### PR TITLE
Add IAM Task role to instance

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -86,7 +86,7 @@ resource "aws_launch_configuration" "tools" {
 
   key_name                    = "${var.key_name}"
   image_id                    = "${data.aws_ami.stable_coreos.id}"
-  instance_type               = "${var.instance_type}"
+  instance_type               = "${var.instance_type_tools_cluster}"
   iam_instance_profile        = "${aws_iam_instance_profile.app.name}"
   user_data                   = "${data.template_file.tools_userdata.rendered}"
   associate_public_ip_address = true

--- a/terraform/userdata/ecs-agent-tools.yml
+++ b/terraform/userdata/ecs-agent-tools.yml
@@ -42,9 +42,12 @@ coreos:
                                      --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
                                      --volume=/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro \
                                      --publish=127.0.0.1:51678:51678 \
+                                     --net=host \
                                      --env=ECS_LOGFILE=/log/ecs-agent.log \
                                      --env=ECS_LOGLEVEL=$${ECS_LOGLEVEL} \
                                      --env=ECS_DATADIR=/data \
+                                     --env=ECS_ENABLE_TASK_IAM_ROLE=true \
+                                     --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
                                      --env=ECS_CLUSTER=$${ECS_CLUSTER} \
                                      --env=ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs"]' \
                                      --log-driver=awslogs \

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,6 +17,11 @@ variable "instance_type" {
   description = "AWS instance type"
 }
 
+variable "instance_type_tools_cluster" {
+  default     = "t2.medium"
+  description = "AWS instance type"
+}
+
 variable "asg_min" {
   description = "Min numbers of servers in ASG"
   default     = "1"


### PR DESCRIPTION
In order that Jenkins can perform terraform operations.
So that we can deploy infrastructure changes from inside AWS.