### PR TITLE
Prevent EFS filesystem from being accidentally destroyed

### DIFF
--- a/terraform/efs.tf
+++ b/terraform/efs.tf
@@ -1,4 +1,8 @@
-resource "aws_efs_file_system" "jenkins" { }
+resource "aws_efs_file_system" "jenkins" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "aws_efs_mount_target" "jenkins" {
   count           = "${var.az_count}"


### PR DESCRIPTION
Adds 'prevent_destroy' to EFS resource `lifecycle` block.

https://www.terraform.io/docs/configuration/resources.html#prevent_destroy.