### PR TITLE
Provide Jenkins access to volume from host mount

### DIFF
--- a/terraform/efs.tf
+++ b/terraform/efs.tf
@@ -1,4 +1,8 @@
-resource "aws_efs_file_system" "jenkins" { }
+resource "aws_efs_file_system" "jenkins" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "aws_efs_mount_target" "jenkins" {
   count           = "${var.az_count}"

--- a/terraform/userdata/ecs-agent-tools.yml
+++ b/terraform/userdata/ecs-agent-tools.yml
@@ -1,4 +1,7 @@
 #cloud-config
+users:
+  - name: "jenkins"
+  - homedir: "/mnt/efs"
 coreos:
   units:
    - name: rpc-statd.service


### PR DESCRIPTION
When containerised and accessing jenkins_home via a volume backed on to
a mount on the host, the permissions of the mount persist through to
the container. By default the permissions of an EFS mount as here are
write for root only and consequently jenkins inside the container cannot
write to it's assigned volume.

Adding jenkins as the owner on the host resolves this issue.
