### PR TITLE
Fixes for the Calm adapter scheduler

### DIFF
--- a/lambdas/update_ecs_service_size.py
+++ b/lambdas/update_ecs_service_size.py
@@ -34,7 +34,7 @@ def change_desired_count(cluster, service, desired_count):
 
 def main(event, _):
     print('Received event: %r' % event)
-    message = event['Message']
+    message = event['Records'][0]['Sns']['Message']
     message_data = json.loads(message)
 
     change_desired_count(

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,5 +1,5 @@
-resource "aws_cloudwatch_event_rule" "once_a_day" {
-  name                = "once-a-day"
-  description         = "Fires once a day"
-  schedule_expression = "rate(1 day)"
+resource "aws_cloudwatch_event_rule" "daily_2am" {
+  name                = "daily_2am"
+  description         = "Fires once a day at 2am"
+  schedule_expression = "cron(* 2 * * *)"
 }

--- a/terraform/lambda/outputs.tf
+++ b/terraform/lambda/outputs.tf
@@ -1,11 +1,11 @@
 output "arn" {
   description = "ARN of the Lambda function"
-  value = "${aws_lambda_function.lambda_function.arn}"
+  value       = "${aws_lambda_function.lambda_function.arn}"
 }
 
 output "function_name" {
   description = "Name of the Lambda function"
-  value = "${aws_lambda_function.lambda_function.function_name}"
+  value       = "${aws_lambda_function.lambda_function.function_name}"
 }
 
 output "role_name" {

--- a/terraform/lambda_publish_to_sns.tf
+++ b/terraform/lambda_publish_to_sns.tf
@@ -1,6 +1,4 @@
-/*
-  Lambda for publishing ECS service schedules to an SNS topic.
- */
+/** Lambda for publishing ECS service schedules to an SNS topic. */
 
 module "publish_to_sns_lambda" {
   source      = "./lambda"
@@ -9,12 +7,12 @@ module "publish_to_sns_lambda" {
   filename    = "../lambdas/publish_to_sns.py"
 }
 
-module "publish_to_sns_trigger" {
+module "schedule_calm_adapter" {
   source                  = "./lambda/trigger_cloudwatch"
   lambda_function_name    = "${module.publish_to_sns_lambda.function_name}"
   lambda_function_arn     = "${module.publish_to_sns_lambda.arn}"
-  cloudwatch_trigger_arn  = "${aws_cloudwatch_event_rule.once_a_day.arn}"
-  cloudwatch_trigger_name = "${aws_cloudwatch_event_rule.once_a_day.name}"
+  cloudwatch_trigger_arn  = "${aws_cloudwatch_event_rule.daily_2am.arn}"
+  cloudwatch_trigger_name = "${aws_cloudwatch_event_rule.daily_2am.name}"
 
   input = <<EOF
 {


### PR DESCRIPTION
* Fix the Lambda (look at the CloudWatch logs to see what event we’re actually receiving)
* Run it at 2am, rather than whenever CloudWatch feels like

I still haven’t really worked out the repo layout for this code. 😕 

Once this is applied, I’ll manually ramp up the CloudWatch schedule to something much faster, just so I can test it’s working correctly.