### PR TITLE
Tweak the schedule of the Calm adapter

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,5 +1,5 @@
-resource "aws_cloudwatch_event_rule" "daily_2am" {
-  name                = "daily_2am"
-  description         = "Fires once a day at 2am"
-  schedule_expression = "cron(0 2 ? * MON-SUN *)"
+resource "aws_cloudwatch_event_rule" "weekdays_at_7am" {
+  name                = "weekdays_at_7am"
+  description         = "Fires at 7am on weekdays"
+  schedule_expression = "cron(0 7 ? * MON-FRI *)"
 }

--- a/terraform/lambda_publish_to_sns.tf
+++ b/terraform/lambda_publish_to_sns.tf
@@ -11,8 +11,8 @@ module "schedule_calm_adapter" {
   source                  = "./lambda/trigger_cloudwatch"
   lambda_function_name    = "${module.publish_to_sns_lambda.function_name}"
   lambda_function_arn     = "${module.publish_to_sns_lambda.arn}"
-  cloudwatch_trigger_arn  = "${aws_cloudwatch_event_rule.daily_2am.arn}"
-  cloudwatch_trigger_name = "${aws_cloudwatch_event_rule.daily_2am.name}"
+  cloudwatch_trigger_arn  = "${aws_cloudwatch_event_rule.weekdays_at_7am.arn}"
+  cloudwatch_trigger_name = "${aws_cloudwatch_event_rule.weekdays_at_7am.name}"
 
   input = <<EOF
 {


### PR DESCRIPTION
Running at 2am is fine for overnight builds that don't cost any money, but a weekday schedule shortly before working hours makes more sense here.  If somebody does go wrong and the Dynamo table gets stuck on the expensive tier, we'll be able to fix it more quickly.

---

Prompted by @jamesgorrie’s comments in demos this afternoon.

(I used to run overnights on VMware kit that was paid for up-front and continuously running, so 2am was fine. Err, oops.)
