### PR TITLE
Give the Calm adapter the correct permissions

### DIFF
--- a/terraform/lambda_publish_to_sns.tf
+++ b/terraform/lambda_publish_to_sns.tf
@@ -23,21 +23,3 @@ module "schedule_calm_adapter" {
 }
 EOF
 }
-
-data "aws_iam_policy_document" "publish_to_sns" {
-  statement {
-    actions = [
-      "sns:Publish",
-    ]
-
-    resources = [
-      "${aws_sns_topic.service_scheduler_topic.arn}",
-    ]
-  }
-}
-
-resource "aws_iam_role_policy" "publish_to_sns_lambda_policy" {
-  name   = "publish_to_sns_policy"
-  role   = "${module.publish_to_sns_lambda.role_name}"
-  policy = "${data.aws_iam_policy_document.publish_to_sns.json}"
-}


### PR DESCRIPTION
The Calm adapter needs permission to write to the SNS topic, or
it can't turn itself off at the end of the run.