### PR TITLE
Add Dockerfile for fake-sns image

### DIFF
--- a/docker/fake-sns/Dockerfile
+++ b/docker/fake-sns/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:alpine
+
+RUN apk update
+RUN apk upgrade
+RUN apk add git
+RUN gem install specific_install
+RUN gem specific_install -l https://github.com/elruwen/fake_sns -b feature-fixed-account-id 
+
+CMD ["fake_sns"]
+EXPOSE 9292
+


### PR DESCRIPTION
Add Dockerfile for the fake-sns image we use in integration tests for platform-api