### PR TITLE
Swap out our Jenkins container to run as root

### DIFF
--- a/terraform/services/ecs_tasks/templates/jenkins.json.template
+++ b/terraform/services/ecs_tasks/templates/jenkins.json.template
@@ -20,6 +20,7 @@
         "sourceVolume": "jenkins-home",
         "containerPath": "/var/jenkins_home"
       }
-    ]
+    ],
+    "user": "root"
   }
 ]


### PR DESCRIPTION
Resolves #48.

Might be better to sort out the EFS mount so it’s owned by the Jenkins user, but this gets us going for now.