### PR TITLE
Minor fixes to the plan.sh shell script

### DIFF
--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -6,6 +6,8 @@ set -o verbose
 
 TF_VARS=terraform.tfvars
 
+rm -f $TF_VARS
+
 echo "Getting variables from S3"
 aws s3 cp s3://platform-infra/terraform.tfvars .
 

--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 
-set -x
-set -e
 set -o errexit
 set -o nounset
+set -o verbose
 
 TF_VARS=terraform.tfvars
-
-[ -e $TF_VARS] && rm $TF_VARS
 
 echo "Getting variables from S3"
 aws s3 cp s3://platform-infra/terraform.tfvars .
 
 terraform init
 terraform get
-terraform plan
+terraform plan -out terraform.plan
 
-echo "Please review the above plan. If you are happy then run 'terraform apply'"
+echo "Please review the above plan. If you are happy then run 'terraform apply terraform.plan'"


### PR DESCRIPTION
*   `aws s3 cp` will overwrite an existing `.tfvars` file, so no need to delete it.  Besides, that line had a syntax error:

        + '[' -e 'terraform.tfvars]'
        ./plan.sh: line 10: [: missing `]'

*   Send the terraform plan via a planfile.  Previously we got an error when running the `plan` command:

        Note: You didn't specify an "-out" parameter to save this plan, so when
        "apply" is called, Terraform can't guarantee this is what will execute.

*   Use `set -o verbose` instead of `set -x` for readability.  And `set -e` is the same as `set -o errexit`, we don't need both.