### PR TITLE
Check we're using the latest ECR image before planning

### DIFF
--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -11,6 +11,23 @@ rm -f $TF_VARS
 echo "Getting variables from S3"
 aws s3 cp s3://platform-infra/terraform.tfvars .
 
+latest_image_id="$(aws ecr describe-images --repository-name uk.ac.wellcome/api | jq -r '.imageDetails | max_by(.imagePushedAt) | .imageTags[0]')"
+if ! grep -q "$latest_image_id" terraform.tfvars
+then
+    echo ""
+    echo "WARNING! You may be about to downgrade to an older version of the API."
+    echo "The latest ECR image ID is $latest_image_id."
+    echo "This does not match the image ID in your terraform.tfvars file."
+    echo ""
+    echo "To continue, type 'downgrade'."
+    read resp
+    if [[ "$resp" != "downgrade" ]]
+    then
+        echo "Aborting..."
+        exit 1
+    fi
+fi
+
 terraform init
 terraform get
 terraform plan -out terraform.plan


### PR DESCRIPTION
Multiple times, somebody has run a 'terraform plan' and caused problems because they've rolled back the deployed version.  This patch enhances the 'plan' script to check if you're using the latest ECR image, and warns you if not.