### PR TITLE
Minor fixes for config-in-S3

### DIFF
--- a/terraform/ecs_iam/task_role.tf
+++ b/terraform/ecs_iam/task_role.tf
@@ -15,3 +15,25 @@ data "aws_iam_policy_document" "assume_ecs_role" {
     }
   }
 }
+
+resource "aws_iam_role_policy" "s3_role" {
+  name   = "${var.name}_read_from_s3"
+  role   = "${aws_iam_role.task_role.name}"
+  policy = "${data.aws_iam_policy_document.allow_s3_read.json}"
+}
+
+# Our applications read their config from S3 on startup, make sure they
+# have the appropriate read permissions.
+# TODO: Scope these more tightly, possibly at the bucket or even object level.
+data "aws_iam_policy_document" "allow_s3_read" {
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/terraform/services/config/templates/api.ini.template
+++ b/terraform/services/config/templates/api.ini.template
@@ -4,5 +4,5 @@
 -es.sniff=false
 -es.xpack.enabled=true
 -es.xpack.user=${es_xpack_user}
--es.sslEnabled=true
+-es.xpack.sslEnabled=true
 -es.transport.compress=true

--- a/terraform/services/config/templates/ingestor.ini.template
+++ b/terraform/services/config/templates/ingestor.ini.template
@@ -6,6 +6,6 @@
 -es.sniff=false
 -es.xpack.enabled=true
 -es.xpack.user=${es_xpack_user}
--es.sslEnabled=true
+-es.xpack.sslEnabled=true
 -es.transport.compress=true
 -aws.sqs.queue.url=${ingest_queue_id}

--- a/terraform/services/ecs_service/ecs.tf
+++ b/terraform/services/ecs_service/ecs.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_service" "service" {
   iam_role        = "${aws_iam_role.ecs_service.name}"
 
   load_balancer {
-    target_group_arn = "${aws_alb_target_group.ecs_service.id}"
+    target_group_arn = "${aws_alb_target_group.ecs_service.arn}"
     container_name   = "${var.container_name}"
     container_port   = "${var.container_port}"
   }

--- a/terraform/services/ecs_service/iam.tf
+++ b/terraform/services/ecs_service/iam.tf
@@ -38,22 +38,3 @@ data "aws_iam_policy_document" "ecs_service" {
     ]
   }
 }
-
-resource "aws_iam_role_policy" "read_from_s3" {
-  name   = "${var.service_name}_read_from_s3"
-  role   = "${aws_iam_role.ecs_service.name}"
-  policy = "${data.aws_iam_policy_document.read_from_s3_infra.json}"
-}
-
-data "aws_iam_policy_document" "read_from_s3_infra" {
-  statement {
-    actions = [
-      "s3:GetObject",
-      "s3:ListBucket",
-    ]
-
-    resources = [
-      "arn:aws:s3:::${var.infra_bucket}",
-    ]
-  }
-}

--- a/terraform/services/ecs_service/iam.tf
+++ b/terraform/services/ecs_service/iam.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "assume_ecs_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
+      identifiers = ["ecs.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
This resolves a few issues I ran into after deploying the initial version of config-loaded-from-S3:

* When I did the IAM cleanup in #57, I changed an "ecs.amazon.com" to "ecs-tasks.amazon.com", which upset the ALB.
* I was applying S3 read permissions to the wrong objects.
* Some extra script fixes