### PR TITLE
Adding travis_ci user and the iam policy to access S3 and ECR

### DIFF
--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -162,3 +162,30 @@ data "aws_iam_policy_document" "stop_running_tasks" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "travis_permissions" {
+  statement {
+    actions = [
+      "ecr:*",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.api.arn}",
+      "${aws_ecr_repository.transformer.arn}",
+      "${aws_ecr_repository.ingestor.arn}",
+      "${aws_ecr_repository.id_minter.arn}",
+      "${aws_ecr_repository.calm_adapter.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.infra.arn}",
+    ]
+  }
+}

--- a/terraform/iam_users.tf
+++ b/terraform/iam_users.tf
@@ -1,0 +1,12 @@
+resource "aws_iam_user" "travis_ci" {
+  name = "travis_ci"
+}
+
+resource "aws_iam_access_key" "travis_ci" {
+  user = "${aws_iam_user.travis_ci.name}"
+}
+
+resource "aws_iam_user_policy" "travis_ci" {
+  user = "${aws_iam_user.travis_ci.name}"
+  policy = "${data.aws_iam_policy_document.travis_permissions.json}"
+}

--- a/terraform/iam_users.tf
+++ b/terraform/iam_users.tf
@@ -7,6 +7,6 @@ resource "aws_iam_access_key" "travis_ci" {
 }
 
 resource "aws_iam_user_policy" "travis_ci" {
-  user = "${aws_iam_user.travis_ci.name}"
+  user   = "${aws_iam_user.travis_ci.name}"
   policy = "${data.aws_iam_policy_document.travis_permissions.json}"
 }


### PR DESCRIPTION
At the moment the user that Travis Ci uses to access AWS services is configured manually. It should be part of our infrastructure provisioning
