### PR TITLE
Remove release-id variable as it's not used anymore

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,10 +16,6 @@ variable "admin_cidr_ingress" {
   description = "CIDR to allow tcp/22 ingress to EC2 instance"
 }
 
-variable "release_id" {
-  description = "Release tag for platform image"
-}
-
 variable "release_ids" {
   description = "Release tags for platform apps"
   type        = "map"


### PR DESCRIPTION
I removed release_id variable from terraform.tfvars as it's not used anymore and it was just confusing. terraform plan fails though, cause the variable is till declared in the list of variables. So this should fix this

- [x] Run `terraform apply`.
