### PR TITLE
Give schedule_reindexer lambda permission to publish to sns

### DIFF
--- a/terraform/iam_role_policy.tf
+++ b/terraform/iam_role_policy.tf
@@ -74,6 +74,12 @@ resource "aws_iam_role_policy" "lambda_service_scheduler_sns" {
   policy = "${module.service_scheduler_topic.publish_policy}"
 }
 
+resource "aws_iam_role_policy" "lambda_schedule_reindexer_sns" {
+  name   = "lambda_schedule_reindexer_sns"
+  role   = "${module.lambda_schedule_reindexer.role_name}"
+  policy = "${module.service_scheduler_topic.publish_policy}"
+}
+
 # Role policies for the Update ECS Service Size Lambda
 
 resource "aws_iam_role_policy" "update_ecs_service_size_policy" {


### PR DESCRIPTION
## What is this PR trying to achieve?
Make schedule_reindexer not fail when trying to publish to SNS
## Who is this change for?
Devs
## Have the following been considered/are they needed?

- [ ] Tests?
- [ ] Docs?
- [ ] Spoken to the right people?

---

<!-- Remove this section if you don't have Terraform changes -->

- [x] Run `terraform apply`.
