### PR TITLE
Make the id_minter receive messages only once

### DIFF
--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -15,5 +15,7 @@ variable "environment_variables" {
   type        = "map"
 
   # environment cannot be emtpy so we need to pass at least one value
-  default     = {EMPTY_VARIABLE = ""}
+  default = {
+    EMPTY_VARIABLE = ""
+  }
 }

--- a/terraform/queues.tf
+++ b/terraform/queues.tf
@@ -7,10 +7,10 @@ module "es_ingest_queue" {
 }
 
 module "id_minter_queue" {
-  source      = "./sqs"
-  queue_name  = "id_minter_queue"
-  aws_region  = "${var.aws_region}"
-  account_id  = "${data.aws_caller_identity.current.account_id}"
-  topic_names = ["${module.id_minter_topic.name}"]
+  source            = "./sqs"
+  queue_name        = "id_minter_queue"
+  aws_region        = "${var.aws_region}"
+  account_id        = "${data.aws_caller_identity.current.account_id}"
+  topic_names       = ["${module.id_minter_topic.name}"]
   max_receive_count = "1"
 }

--- a/terraform/queues.tf
+++ b/terraform/queues.tf
@@ -12,4 +12,5 @@ module "id_minter_queue" {
   aws_region  = "${var.aws_region}"
   account_id  = "${data.aws_caller_identity.current.account_id}"
   topic_names = ["${module.id_minter_topic.name}"]
+  max_receive_count = "1"
 }


### PR DESCRIPTION
### What is this PR trying to achieve?
If the id minter takes longer than the SQS visibility timeout to process a message, the message is resent and it might result in the same item being assigned two ids, which then makes everything crap out. So this change is to make that more unlikely until we design a more solid solution
### Who is this change for?
Devs and anyone who cares about our ingested content
---

<!-- Remove this section if you don't have Terraform changes -->

- [ ] Run `terraform apply`.
