### PR TITLE
Make sure our config-updater Lambda can pass the IAM role

### DIFF
--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -108,6 +108,7 @@ data "aws_iam_policy_document" "stop_running_tasks" {
       "ecs:ListServices",
       "ecs:RegisterTaskDefinition",
       "ecs:UpdateService",
+      "iam:PassRole",
     ]
 
     resources = [


### PR DESCRIPTION
### What is this PR trying to achieve?

Make sure that when we update the config, our services really do restart.

When creating a new task definition for one of our services after the config changes, we need to be able to copy the IAM role from the previous task definition.  That only works if the copying Lambda has the "PassRole" permission.

Resolves https://github.com/wellcometrust/platform-api/issues/374.

### Who is this change for?

Developers who like working infrastructure.

---

<!-- Remove this section if you don't have Terraform changes -->

- [x] Run `terraform apply`.