### PR TITLE
Increase API instance size to match task requirement

### DIFF
--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -19,4 +19,5 @@ module "api_cluster_asg" {
   instance_profile_name = "${module.ecs_api_iam.instance_profile_name}"
   user_data             = "${module.api_userdata.rendered}"
   vpc_id                = "${module.vpc_api.vpc_id}"
+  instance_type         = "t2.large"
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

The API won't run in its current state because it asks for more memory than available to ec2 instances in its cluster.

### Who is this change for?

Consumers of the API

---

- [ ] Run `terraform apply`.
