### PR TITLE
Delete identifiers dynamo table

### DIFF
--- a/terraform/dynamo.tf
+++ b/terraform/dynamo.tf
@@ -64,6 +64,7 @@ resource "aws_dynamodb_table" "calm_table" {
 
   lifecycle {
     prevent_destroy = true
+
     ignore_changes = [
       "read_capacity",
       "write_capacity",
@@ -111,39 +112,7 @@ resource "aws_dynamodb_table" "miro_table" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes = [
-      "read_capacity",
-      "write_capacity",
-    ]
-  }
-}
 
-resource "aws_dynamodb_table" "identifiers" {
-  name           = "Identifiers"
-  read_capacity  = 5
-  write_capacity = 5
-  hash_key       = "CanonicalID"
-
-  attribute {
-    name = "CanonicalID"
-    type = "S"
-  }
-
-  attribute {
-    name = "MiroID"
-    type = "S"
-  }
-
-  global_secondary_index = {
-    name            = "MiroID"
-    hash_key        = "MiroID"
-    read_capacity   = 5
-    write_capacity  = 5
-    projection_type = "ALL"
-  }
-
-  lifecycle {
-    prevent_destroy = true
     ignore_changes = [
       "read_capacity",
       "write_capacity",
@@ -166,6 +135,7 @@ resource "aws_dynamodb_table" "reindex_tracker" {
 
   lifecycle {
     prevent_destroy = true
+
     ignore_changes = [
       "read_capacity",
       "write_capacity",

--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -74,19 +74,6 @@ data "aws_iam_policy_document" "read_calm_kinesis_stream" {
   }
 }
 
-data "aws_iam_policy_document" "read_write_dynamo_identifiers_table" {
-  statement {
-    actions = [
-      "dynamodb:*",
-    ]
-
-    resources = [
-      "${aws_dynamodb_table.identifiers.arn}",
-      "${aws_dynamodb_table.identifiers.arn}/index/*",
-    ]
-  }
-}
-
 data "aws_iam_policy_document" "update_ecs_service_size" {
   statement {
     actions = [

--- a/terraform/iam_role_policy.tf
+++ b/terraform/iam_role_policy.tf
@@ -60,12 +60,6 @@ resource "aws_iam_role_policy" "ecs_id_minter_task_read_id_minter_q" {
   policy = "${module.id_minter_queue.read_policy}"
 }
 
-resource "aws_iam_role_policy" "ecs_id_minter_task_dynamo_identifiers_table" {
-  name   = "ecs_task_id_minter_dynamo_identifiers_policy"
-  role   = "${module.ecs_id_minter_iam.task_role_name}"
-  policy = "${data.aws_iam_policy_document.read_write_dynamo_identifiers_table.json}"
-}
-
 # Role policies for the Publish to SNS Lambda
 
 resource "aws_iam_role_policy" "lambda_service_scheduler_sns" {


### PR DESCRIPTION
### What is this PR trying to achieve?
Delete identifiers dynamo db table, as the id minter doesn't use it anymore
### Who is this change for?
Everyone

---

<!-- Remove this section if you don't have Terraform changes -->

- [x] Run `terraform apply`.
